### PR TITLE
Capture transcript in ACMG model

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,8 @@ __versionstr__ = '.'.join(map(str, VERSION))
 here = path.abspath(path.dirname(__file__))
 installation_requirements = [
     'requests>=2.0.0, <3.0.0',
-    'PyVCF>=0.6.8',
+    #'PyVCF>=0.6.8',
+    'PyVCF>=0.4.3',
     'jsonmodels>=2.2'
 ]
 if sys.version_info < (3, 4):

--- a/varsome_api/models/elements/acmg.py
+++ b/varsome_api/models/elements/acmg.py
@@ -40,3 +40,4 @@ class ACMG(models.Base):
     classifications = fields.ListField(required=False, items_types=(ACMGClassification,),
                                        help_text="ACMG Classifications")
     verdict = fields.EmbeddedField(ACMGVerdict, nullable=True, required=False, help_text="ACMG Verdict")
+    transcript = fields.StringField(required=False, nullable=True)


### PR DESCRIPTION
I wanted to find the HGVS for the ACMG block returned by the API. In order to grab that from the refseq_transcripts or ensembl_transcripts block, I needed the ACMG block's transcript ID, but it wasn't captured by the ACMG model. I added this field to the ACMG model to facilitate this analysis.